### PR TITLE
Enabled data download

### DIFF
--- a/src/components/DownloadDataButton.js
+++ b/src/components/DownloadDataButton.js
@@ -3,25 +3,11 @@ import React from "react";
 import { Button } from "react-bootstrap";
 import "./DownloadButton.css";
 import downloadZip from "./Utils/downloadZip";
-import FileCheck from "./Utils/FileCheck";
 
-export default function DownloadDataButton({
-  plotvars,
-  seasons,
-  periods,
-  plottypes,
-  regions,
-}) {
-  const handleDataDownload = async () => {
-    console.log(plotvars);
-
-    const files = await FileCheck(
-      { plotvars, seasons, periods, plottypes },
-      "nc"
-    );
-
+export default function DownloadDataButton({ datafiles }) {
+  const handleDataDownload = () => {
     // call zip function here
-    return downloadZip(files, "datafiles");
+    return downloadZip(datafiles, "datafiles");
   };
 
   return (

--- a/src/components/DownloadPlotsButton.js
+++ b/src/components/DownloadPlotsButton.js
@@ -4,10 +4,10 @@ import { Button } from "react-bootstrap";
 import "./DownloadButton.css";
 import downloadZip from "./Utils/downloadZip";
 
-function DownloadPlotsButton({ images, downloadnames }) {
+function DownloadPlotsButton({ images }) {
   const handlePlotDownload = () => {
     // call zip function here
-    return downloadZip(images, downloadnames, "plots");
+    return downloadZip(images, "plots");
   };
 
   return (

--- a/src/components/PlotExplorerContainer.js
+++ b/src/components/PlotExplorerContainer.js
@@ -23,7 +23,7 @@ function PlotExplorerContainer() {
   const [plottypes, setPlottypes] = useState([]);
   const [regions, setRegion] = useState([]);
   const [images, setImages] = useState([]);
-  // const [datafiles, setDataFiles] = useState([]);
+  const [datafiles, setDataFiles] = useState([]);
   const [warnings, setWarnings] = useState([]);
 
   // check files as selections are chosen
@@ -45,16 +45,16 @@ function PlotExplorerContainer() {
         "png"
       );
       // Commented for now just because files are not yet available
-      // const datafiles = await FileCheck(
-      //   { plotvars, seasons, periods, plottypes },
-      //   "nc"
-      // );
+      const datafiles = await FileCheck(
+        { plotvars, seasons, periods, plottypes, setWarnings },
+        "nc"
+      );
       if (!active) {
         return;
       }
       setImages(images);
       console.log(images);
-      // setDataFiles(datafiles);
+      setDataFiles(datafiles);
     }
   }, [plotvars, seasons, periods, plottypes]);
 
@@ -98,9 +98,7 @@ function PlotExplorerContainer() {
                 seasons.length >= 1 &&
                 periods.length >= 1 &&
                 regions.length >= 1 && (
-                  <DownloadDataButton
-                  // datafiles={datafiles}
-                  />
+                  <DownloadDataButton datafiles={datafiles} />
                 )}
             </Container>
           </Stack>

--- a/src/components/PlotExplorerContainer.js
+++ b/src/components/PlotExplorerContainer.js
@@ -40,13 +40,14 @@ function PlotExplorerContainer() {
           seasons,
           periods,
           plottypes,
+          regions,
           setWarnings,
         },
         "png"
       );
       // Commented for now just because files are not yet available
       const datafiles = await FileCheck(
-        { plotvars, seasons, periods, plottypes, setWarnings },
+        { plotvars, seasons, periods, plottypes, regions, setWarnings },
         "nc"
       );
       if (!active) {
@@ -56,7 +57,7 @@ function PlotExplorerContainer() {
       console.log(images);
       setDataFiles(datafiles);
     }
-  }, [plotvars, seasons, periods, plottypes]);
+  }, [plotvars, seasons, periods, plottypes, regions]);
 
   return (
     <Container fluid>

--- a/src/components/Utils/downloadZip.js
+++ b/src/components/Utils/downloadZip.js
@@ -24,6 +24,6 @@ export default function downloadZip(filelist, zipname) {
         });
       }
     });
-    return console.log("this needed a return");
+    return null;
   });
 }

--- a/src/components/Utils/downloadZip.js
+++ b/src/components/Utils/downloadZip.js
@@ -2,39 +2,28 @@ import { saveAs } from "file-saver";
 import JSZip from "jszip";
 import JSZipUtils from "jszip-utils";
 
-export default function downloadZip(filelist, filenames, zipname) {
+export default function downloadZip(filelist, zipname) {
   var zip = new JSZip();
   var count = 0;
   var zipFilename = "UKCORDEX_" + zipname + ".zip";
-  var downloads = filelist;
-  var filenamearray = [];
+  var urls = filelist;
 
-  for (let key in filenames) {
-    var fnames = filenames[key];
-
-    // set the name for each image
-    var filename = `${fnames.ptype}_${fnames.pvar}_${fnames.season}_${fnames.period}`;
-    // console.log("downloadname: ", filename);
-    filenamearray.push(filename);
-  }
-
-  downloads.map((file) => {
-    filenamearray.map((filename) => {
-      // loading a file and add it in a zip file
-      JSZipUtils.getBinaryContent(file, function (err, data) {
-        if (err) {
-          throw err; // or handle the error
-        }
-        zip.file(filename, data, { binary: true });
-        count++;
-        if (count === downloads.length) {
-          zip.generateAsync({ type: "blob" }).then(function (content) {
-            saveAs(content, zipFilename);
-          });
-        }
-      });
-      return null; // function is unhappy without return
+  urls.map((url) => {
+    // get the right basename for each image
+    var filename = url.slice(url.lastIndexOf("/") + 1);
+    // loading a file and add it in a zip file
+    JSZipUtils.getBinaryContent(url, function (err, data) {
+      if (err) {
+        throw err; // or handle the error
+      }
+      zip.file(filename, data, { binary: true });
+      count++;
+      if (count === urls.length) {
+        zip.generateAsync({ type: "blob" }).then(function (content) {
+          saveAs(content, zipFilename);
+        });
+      }
     });
-    return null; // function is unhappy without return
+    return console.log("this needed a return");
   });
 }


### PR DESCRIPTION
rolled back to previous version of downloadZip since using URLs again
Added functionality for downloading data files

Related to https://github.com/UCL/UKCORDEX-plot-explorer/issues/18 and closes https://github.com/UCL/UKCORDEX-plot-explorer/issues/41

Related to https://github.com/UCL/UKCORDEX-plot-explorer/issues/50 (would have been done in https://github.com/UCL/UKCORDEX-plot-explorer-dev/pull/26 after)