### PR TITLE
Attempt to fix broken deployment authorisation 

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -43,4 +43,4 @@ jobs:
           branch: gh-pages # The branch the action should deploy to.
           folder: build # The folder the action should deploy.
           repository-name: UCL/UKCORDEX-plot-explorer
-          token: ${{secrets.DEPLOYMENT_TO_PROD}}
+          ssh-key: ${{secrets.DEPLOY_KEY}}


### PR DESCRIPTION
This PR replaces the token that (presumably) was generated by Raquel and has now stopped working since her untimely departure. The new method uses a pair of ssh keys where the public key is provided to the production repo as a deploy key and the private to this repository as a secret for use in the deploy action.